### PR TITLE
Ensure timeouts are called with the proper context.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,9 +1,9 @@
 // DOM APIs, for completeness
 
-if (typeof setTimeout !== 'undefined') exports.setTimeout = setTimeout;
-if (typeof clearTimeout !== 'undefined') exports.clearTimeout = clearTimeout;
-if (typeof setInterval !== 'undefined') exports.setInterval = setInterval;
-if (typeof clearInterval !== 'undefined') exports.clearInterval = clearInterval;
+if (typeof setTimeout !== 'undefined') exports.setTimeout = function() { setTimeout.apply(window, arguments); };
+if (typeof clearTimeout !== 'undefined') exports.clearTimeout = function() { clearTimeout.apply(window, arguments); };
+if (typeof setInterval !== 'undefined') exports.setInterval = function() { setInterval.apply(window, arguments); };
+if (typeof clearInterval !== 'undefined') exports.clearInterval = function() { clearInterval.apply(window, arguments); };
 
 // TODO: Change to more effiecient list approach used in Node.js
 // For now, we just implement the APIs using the primitives above.


### PR DESCRIPTION
Otherwise, you're invoking the public timeout methods on the exports
object, e.g.:

``` javascript
require('timers').setTimeout(function() {
    // do things
}, 500);
```

will result in an Illegal invocation type error in chrome, because
`this` of `setTimeout` will point to the timers' module.exports
instead of window.

These are just pass-through methods that do no type checking, etc,
and apply the arguments directly to method with the context of
`window`.
