### PR TITLE
Replace immediate implementation with setimmediate polyfill

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,8 +1,4 @@
-var nextTick = require('process/browser.js').nextTick;
 var apply = Function.prototype.apply;
-var slice = Array.prototype.slice;
-var immediateIds = {};
-var nextImmediateId = 0;
 
 // DOM APIs, for completeness
 
@@ -47,30 +43,7 @@ exports._unrefActive = exports.active = function(item) {
   }
 };
 
-// That's not how node.js implements it but the exposed api is the same.
-exports.setImmediate = typeof setImmediate === "function" ? setImmediate : function(fn) {
-  var id = nextImmediateId++;
-  var args = arguments.length < 2 ? false : slice.call(arguments, 1);
-
-  immediateIds[id] = true;
-
-  nextTick(function onNextTick() {
-    if (immediateIds[id]) {
-      // fn.call() is faster so we optimize for the common use-case
-      // @see http://jsperf.com/call-apply-segu
-      if (args) {
-        fn.apply(null, args);
-      } else {
-        fn.call(null);
-      }
-      // Prevent ids from leaking
-      exports.clearImmediate(id);
-    }
-  });
-
-  return id;
-};
-
-exports.clearImmediate = typeof clearImmediate === "function" ? clearImmediate : function(id) {
-  delete immediateIds[id];
-};
+// setimmediate attaches itself to the global object
+require("setimmediate");
+exports.setImmediate = setImmediate;
+exports.clearImmediate = clearImmediate;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "main": "main.js",
   "dependencies": {
-    "process": "~0.11.0"
+    "setimmediate": "^1.0.4"
   },
   "devDependencies": {
     "connect": "~2.3.0",


### PR DESCRIPTION
This PR replaces our `setImmediate` implementation with the [setImmediate](https://github.com/YuzuJS/setImmediate) polyfill by @YuzuJS. The polyfill seems to be more browser compatible and better tested than the current solution. It especially [avoids a bug in safari which caused crashes](https://github.com/webpack/webpack/issues/756#issuecomment-200004276).

The only downside of this is that the polyfill attaches itself to the global object as soon as it is required. I don't know if that is acceptable. I would say yes, but it definitely changes the behavior.