### PR TITLE
handle clearInterval being called with undefined

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,11 @@ exports.setInterval = function() {
   return new Timeout(apply.call(setInterval, window, arguments), clearInterval);
 };
 exports.clearTimeout =
-exports.clearInterval = function(timeout) { timeout.close(); };
+exports.clearInterval = function(timeout) {
+  if (timeout) {
+    timeout.close();
+  }
+};
 
 function Timeout(id, clearFn) {
   this._id = id;


### PR DESCRIPTION
The native implementation window.clearTimeout(ID) does not error when the provided ID is undefined.
This change makes the behavior of both APIs consistent in this case